### PR TITLE
Use GtkType rather than guint for types

### DIFF
--- a/src/gtkmeter.c
+++ b/src/gtkmeter.c
@@ -48,10 +48,10 @@ static float iec_scale(float db);
 
 static GtkWidgetClass *parent_class = NULL;
 
-guint
+GtkType
 gtk_meter_get_type ()
 {
-  static guint meter_type = 0;
+  static GtkType meter_type = 0;
 
   if (!meter_type)
     {

--- a/src/gtkmeter.h
+++ b/src/gtkmeter.h
@@ -87,7 +87,7 @@ struct _GtkMeterClass
 GtkWidget*     gtk_meter_new                    (GtkAdjustment *adjustment,
 						 gint direction);
 
-guint          gtk_meter_get_type               (void);
+GtkType        gtk_meter_get_type               (void);
 GtkAdjustment* gtk_meter_get_adjustment         (GtkMeter     *meter);
 
 void           gtk_meter_set_adjustment         (GtkMeter     *meter,

--- a/src/gtkmeterscale.c
+++ b/src/gtkmeterscale.c
@@ -45,10 +45,10 @@ static void meterscale_draw_notch(GtkMeterScale *meterscale, float db, int
 
 static GtkWidgetClass *parent_class = NULL;
 
-guint
+GtkType
 gtk_meterscale_get_type ()
 {
-  static guint meterscale_type = 0;
+  static GtkType meterscale_type = 0;
 
   if (!meterscale_type)
     {

--- a/src/gtkmeterscale.h
+++ b/src/gtkmeterscale.h
@@ -67,7 +67,7 @@ GtkWidget*     gtk_meterscale_new               (gint direction,
 						 gfloat min,
 						 gfloat max);
 
-guint          gtk_meterscale_get_type          (void);
+GtkType        gtk_meterscale_get_type          (void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
GtkType is actually a pointer internally, so guint isn't big enough on amd64.

(I guess this should really be using gobject directly these days, but that's a problem for another time...)

Fixes #6 